### PR TITLE
Move badge to original location relative to actionbar icon

### DIFF
--- a/workbench.main.css
+++ b/workbench.main.css
@@ -39,6 +39,10 @@
   width: 100%;
 }
 
+.monaco-workbench .activitybar .content .monaco-action-bar .badge .badge-content {
+   right: 22px;
+}
+
 .monaco-workbench .activitybar {
   -webkit-app-region: drag; /* Allow dragging on the wider activitybar */
 }


### PR DESCRIPTION
* Without `vscode-titlebar-less-macos`, the badge-content has `right: 8px`.

* With the wider action-bar from `vscode-titlebar-less-macos`, the badge-content is 14px to the right of its original location.

This PR restores the original position of badges relative to action-bar icons:

| without `vscode-titlebar-less-macos` | with `vscode-titlebar-less-macos` | with this PR |
|:---:|:---:|:---:|
|  <img width="996" alt="original" src="https://user-images.githubusercontent.com/3104489/43030641-d37eddee-8c47-11e8-8d5e-f8ef28996d96.png"> | <img width="996" alt="before" src="https://user-images.githubusercontent.com/3104489/43030587-0f65596a-8c47-11e8-9ae7-8cc6580a633c.png"> | <img width="996" alt="after" src="https://user-images.githubusercontent.com/3104489/43030589-1484b760-8c47-11e8-8c87-12b67b84f0ff.png"> |