### PR TITLE
Support dragging tab bar in recent versions of VS Code

### DIFF
--- a/workbench.main.css
+++ b/workbench.main.css
@@ -55,10 +55,12 @@
   -webkit-app-region: no-drag; /* Still allow to click actions without dragging though */
 }
 
-.monaco-workbench .part.editor .content .one-editor-silo .container .title .tabs-container {
+.monaco-workbench .part.editor .content .one-editor-silo .container .title .tabs-container,
+.monaco-workbench .part.editor .content .editor-group-container .title .tabs-container {
   -webkit-app-region: drag; /* Allow dragging on empty space in tabs */
 }
 
-.monaco-workbench .part.editor .content .one-editor-silo .container .title .tabs-container .tab {
+.monaco-workbench .part.editor .content .one-editor-silo .container .title .tabs-container .tab,
+.monaco-workbench .part.editor .content .editor-group-container .title .tabs-container .tab {
   -webkit-app-region: no-drag; /* Allow dragging tabs to re-order */
 }


### PR DESCRIPTION
In April 2018, VS Code replaced the `.one-editor-silo` class with the `.editor-group-container` class: https://github.com/Microsoft/vscode/commit/bd35d2e15bc2a88aa9ea857cbd6c407d5d225c1a (for example, see `src/vs/workbench/browser/parts/editor2/media/nextNoTabsTitleControl.css`)

This PR adds support for the new class used in post-April-2018 versions of VS Code (which otherwise did not support dragging the window via the tab bar), and retains support for pre-April-2018 versions of VS Code.