### PR TITLE
Docs: window.nativeFullScreen can't be false

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ these lines:
 ```json
 "window.titleBarStyle": "custom",
 "window.nativeTabs": false,
+"window.nativeFullScreen": false,
  ```
 
 ## Applying the Patches as Root


### PR DESCRIPTION
Fixes https://github.com/lehni/vscode-titlebar-less-macos/issues/32

I didn't dive into the code to see if it's a bug or an actual requirement, but we can't have `"window.nativeFullScreen": false` when using this extension. It's fine with me but is worth documenting!