### PR TITLE
Add setting to toggle the traffic light buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 1.10.0
+
+- Add setting to toggle the traffic light buttons.
+
 ## Version 1.9.1
 
 - Make new patch adjustments actually for VSCode v1.33.0, not just v1.34.0 🤦‍

--- a/extension.js
+++ b/extension.js
@@ -19,12 +19,6 @@ const patches = {
         ? `.titleBarStyle="${version < 1.26 ? 'hidden-inset' : 'hiddenInset'}",`
         : '.frame=false,'
     ]
-    // experimental:
-    // [
-    //   new RegExp('(\\w+)(.titleBarStyle="hidden",)'),
-    //   (match, opt, assignment) =>
-    //       `${opt}.titleBarStyle="customButtonsOnHover",${opt}.frame=false,`
-    // ],
   ],
   'vs/workbench/workbench.main.js': [
     // Never show the TITLEBAR_PART when "window.titleBarStyle" is "custom" 

--- a/extension.js
+++ b/extension.js
@@ -7,13 +7,24 @@ const fsOptions = { encoding: 'utf8' }
 
 const version = parseFloat(vscode.version)
 
+const { showTrafficLights } = vscode.workspace.getConfiguration('titlebarLess')
+
 const patches = {
   'vs/code/electron-main/main.js': [
-    // Change the Electron titleBarStyle to "hidden-inset"
+    // Override the Electron BrowserWindow options:
+    // https://electronjs.org/docs/api/frameless-window
     [
       '.titleBarStyle="hidden",',
-      `.titleBarStyle="${version < 1.26 ? 'hidden-inset' : 'hiddenInset' }",`
+      showTrafficLights
+        ? `.titleBarStyle="${version < 1.26 ? 'hidden-inset' : 'hiddenInset'}",`
+        : '.frame=false,'
     ]
+    // experimental:
+    // [
+    //   new RegExp('(\\w+)(.titleBarStyle="hidden",)'),
+    //   (match, opt, assignment) =>
+    //       `${opt}.titleBarStyle="customButtonsOnHover",${opt}.frame=false,`
+    // ],
   ],
   'vs/workbench/workbench.main.js': [
     // Never show the TITLEBAR_PART when "window.titleBarStyle" is "custom" 
@@ -77,11 +88,16 @@ const patches = {
           ) {
             // Add .titlebar-less to .monaco-workbench, see workbench.main.css
             this.workbenchContainer.classList.add("titlebar-less");
-            // Set traffic-lights size, taking zoom-factor into account:
-            var factor = ${browser}.getZoomFactor();
-            var width = 78 / factor;
-            var height = 35 / factor;
-            this.partLayoutInfo.activitybar.width = width;
+            ${showTrafficLights
+              ? `// Set traffic-lights size, taking zoom-factor into account:
+                 var factor = ${browser}.getZoomFactor();
+                 var width = 78 / factor;
+                 var height = 35 / factor;
+                 this.partLayoutInfo.activitybar.width = width;`
+          
+              : `var width = 0;
+                 var height = 0;`
+            }
             var style = document.documentElement.style;
             style.setProperty("--traffic-lights-width", width + "px");
             style.setProperty("--traffic-lights-height", height + "px");

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
     "onCommand:titlebarLess.disable"
   ],
   "contributes": {
+    "configuration": {
+      "title": "Titlebar-Less",
+      "properties": {
+        "titlebarLess.showTrafficLights": {
+          "type": "boolean",
+          "default": true,
+          "description": "Toggles the macOS window control buttons. (requires restart)"
+        }
+      }
+    },
     "commands": [
       {
         "command": "titlebarLess.enable",


### PR DESCRIPTION
As per https://github.com/lehni/vscode-titlebar-less-macos/issues/35  :)

I left in some commented code for Electron's experimental "customButtonsOnHover". It removes the border, rounded corners, and shadow from the window – which is super visually confusing, but I figure someone might have a use for it down the road. Feel free to omit.